### PR TITLE
fixed two papers sharing data dir

### DIFF
--- a/code_130304_load_data.m
+++ b/code_130304_load_data.m
@@ -1320,6 +1320,7 @@ insert_data_into_db(dt, ph_ix, datasets_ids(database_ix));
 
 ohya_morishita_2005.source = {'http://scmd.gi.k.u-tokyo.ac.jp/datamine/pnas/mutant_analysis_2011_10_20.tab'};
 ohya_morishita_2005.downloaddate = {'2013-03-12'};
+% watanabe_ohya_2009.pmid = 19466415; % papers share data
 ohya_morishita_2005.pmid = 16365294;
 
 phenotypes = {'Growth, flow cytometry'};


### PR DESCRIPTION
Adding this one line seemed to be an easy way fool my script into thinking the same block of data works for both PMIDs.